### PR TITLE
fix description of messageDisplay functions

### DIFF
--- a/messageDisplay.rst
+++ b/messageDisplay.rst
@@ -33,7 +33,7 @@ getDisplayedMessage(tabId)
 
 .. api-section-annotation-hack:: 
 
-Gets the currently displayed message in the specified tab. It returns null if no messages are selected, or if multiple messages are selected.
+Gets the currently displayed or selected message in the specified tab. It returns null if no messages are displayed or selected, or if multiple messages are displayed or selected.
 
 .. api-header::
    :label: Parameters
@@ -66,7 +66,7 @@ getDisplayedMessages(tabId)
 
 .. api-section-annotation-hack:: -- [Added in TB 81, backported to TB 78.4.0]
 
-Gets an array of the currently displayed messages in the specified tab. The array is empty if no messages are displayed.
+Gets an array of the currently displayed or selected messages in the specified tab. The array is empty if no messages are displayed or selected.
 
 .. api-header::
    :label: Parameters

--- a/messageDisplay.rst
+++ b/messageDisplay.rst
@@ -33,7 +33,7 @@ getDisplayedMessage(tabId)
 
 .. api-section-annotation-hack:: 
 
-Gets the currently displayed or selected message in the specified tab. It returns null if no messages are displayed or selected, or if multiple messages are displayed or selected.
+Gets the currently displayed message in the specified tab. It returns null if no messages are displayed, or if multiple messages are displayed.
 
 .. api-header::
    :label: Parameters
@@ -66,7 +66,7 @@ getDisplayedMessages(tabId)
 
 .. api-section-annotation-hack:: -- [Added in TB 81, backported to TB 78.4.0]
 
-Gets an array of the currently displayed or selected messages in the specified tab. The array is empty if no messages are displayed or selected.
+Gets an array of the currently displayed messages in the specified tab. The array is empty if no messages are displayed.
 
 .. api-header::
    :label: Parameters


### PR DESCRIPTION
It is possible that you don't have the message pane, but only the message list, so there is no message displayed.

I could not find out how it is possible to display multiple messages in a tab, but I guess this references the view you get in the single message pane when you select more than 1 message.
I don't think it is possible to display multiple messages without selecting them in the same tab, but it is possible to select multiple messages without displaying them...