### PR TITLE
Why message.id?

### DIFF
--- a/includes/messages/file.js
+++ b/includes/messages/file.js
@@ -1,7 +1,7 @@
 let attachments = await browser.messages.listAttachments(messageId);
 for (let att of attachments) {
     let file = await browser.messages.getAttachmentFile(
-        message.id,
+        messageId,
         att.partName
     );
     let content = await file.text();


### PR DESCRIPTION
Don't have the context, but according to me it's messageId in the getAttachmentFile() call.

Regards,