### PR TITLE
Add url to Attachment Type

### DIFF
--- a/messages.rst
+++ b/messages.rst
@@ -706,6 +706,14 @@ Represents an attachment in a message.
       :type: (integer)
       
       The size in bytes of this attachment.
+      
+      
+   .. api-member::
+      :name: ``url``
+      :type: (string)
+      :annotation: -- [Added in TB 91]
+      
+      The URL of this attachment as referenced by Thunderbid.
    
 
 .. _messages.MessageHeader:


### PR DESCRIPTION
Did a pull request to releases-comm-central is this direction. Works well for me.

Regards,