### PR TITLE
Adjust addressBooks.provider example code and schema

### DIFF
--- a/includes/addressBooks/onSearchRequest.js
+++ b/includes/addressBooks/onSearchRequest.js
@@ -1,13 +1,19 @@
-messenger.addressBooks.onSearchRequest.addListener(async (node, searchString) => {
+messenger.addressBooks.provider.onSearchRequest.addListener(async (node, searchString, query) => {
     // Return an array of ContactProperties.
-    let response = await fetch("https://people.acme.com/?query=" + searchString);
-    return response.json.map(contact => (
-        { 
-            DisplayName: contact.name, 
-            PrimaryEmail: contact.email
-        }
-    ));
+    let results = [];
+    fetch("https://people.acme.com/?query=" + searchString)
+        .then(response => response.json())
+        .then(contacts => {
+            for (const contact of contacts) {
+                results.push({
+                    DisplayName: contact.name, 
+                    PrimaryEmail: contact.email
+                });
+            }
+            return { results: results, isCompleteResult: true }
+        });
+    
 }, {
-    dirName: "ACME employees",
+    addressBookName: "ACME employees",
     isSecure: true,
 });

--- a/includes/addressBooks/onSearchRequest.js
+++ b/includes/addressBooks/onSearchRequest.js
@@ -1,17 +1,14 @@
 messenger.addressBooks.provider.onSearchRequest.addListener(async (node, searchString, query) => {
-    // Return an array of ContactProperties.
-    let results = [];
-    fetch("https://people.acme.com/?query=" + searchString)
-        .then(response => response.json())
-        .then(contacts => {
-            for (const contact of contacts) {
-                results.push({
-                    DisplayName: contact.name, 
-                    PrimaryEmail: contact.email
-                });
-            }
-            return { results: results, isCompleteResult: true }
-        });
+    let response = await fetch("https://people.acme.com/?query=" + searchString);
+    let json = await response.json();
+    return {
+        isCompleteResult: true,
+        // Return an array of ContactProperties as results.
+        results: json.map(contact => ({
+            DisplayName: contact.name,
+            PrimaryEmail: contact.email
+        }))
+    };
     
 }, {
     addressBookName: "ACME employees",

--- a/overlay/addressBook.json
+++ b/overlay/addressBook.json
@@ -147,9 +147,17 @@
           }
         ],
         "returns": {
-          "type": "array",
-          "items": {
-            "$ref": "contacts.ContactProperties"
+          "type": "object",
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "$ref": "contacts.ContactProperties"
+              }
+            },
+            "isCompleteResult": {
+              "type": "boolean"
+            }
           }
         }
       }


### PR DESCRIPTION
Hopefully this fixes #61 by adjusting the example code and corresponding schema for `addressBooks.provider.onSearchRequest.addListener`. I wonder if addressBooks.provider.rst in the root needs to be updated too?

The main issue was that the documentation was incorrect about the listener's expected return value, but the example had other issues:

- `addListener` was called on `messenger.addressBooks.onSearchRequest` instead of `messenger.addressBooks.provider.onSearchRequest` (`.provider` was missing)
- `response.json` should have been `response.json()`, which return a `Promise`
- `dirName` should have been `addressBookName`

I haven't tested the example code yet, because I don't fully understand working with Promises at this point.