### PR TITLE
Rename instances of thundernest to thunderbird.

### DIFF
--- a/addressBooks.rst
+++ b/addressBooks.rst
@@ -8,7 +8,7 @@ The :doc:`addressBooks` API, also including the :doc:`contacts` and :doc:`mailin
 
 The `Address Books`__ sample extension uses this API.
 
-__ https://github.com/thundernest/sample-extensions/tree/master/addressBooks
+__ https://github.com/thunderbird/sample-extensions/tree/master/addressBooks
 
 .. role:: permission
 

--- a/browserAction.rst
+++ b/browserAction.rst
@@ -9,7 +9,7 @@ The browserAction API first appeared in Thunderbird 64. It is very similar to Fi
 Many of our `sample extensions`__ use a browserAction.
 
 __ https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction
-__ https://github.com/thundernest/sample-extensions
+__ https://github.com/thunderbird/sample-extensions
 
 .. important::
 

--- a/changes/beta75.rst
+++ b/changes/beta75.rst
@@ -31,7 +31,7 @@ compose
   serialise the document back to a string before calling setComposeDetails. `Here's a sample
   extension.`__
 
-  __ https://github.com/thundernest/sample-extensions/tree/master/composeBody
+  __ https://github.com/thunderbird/sample-extensions/tree/master/composeBody
 
 messages
 ========

--- a/cloudFile.rst
+++ b/cloudFile.rst
@@ -8,7 +8,7 @@ The cloudFile (a.k.a. fileLink) API first appeared in Thunderbird 60. It allows 
 
 The `DropBox Uploader`__ sample extension uses this API.
 
-__ https://github.com/thundernest/sample-extensions/tree/master/dropbox
+__ https://github.com/thunderbird/sample-extensions/tree/master/dropbox
 
 .. role:: permission
 

--- a/contacts.rst
+++ b/contacts.rst
@@ -8,7 +8,7 @@ The :doc:`addressBooks` API, also including the :doc:`contacts` and :doc:`mailin
 
 The `Address Books`__ sample extension uses this API.
 
-__ https://github.com/thundernest/sample-extensions/tree/master/addressBooks
+__ https://github.com/thunderbird/sample-extensions/tree/master/addressBooks
 
 .. role:: permission
 

--- a/how-to/experiments.rst
+++ b/how-to/experiments.rst
@@ -16,7 +16,7 @@ Adding an experiment to your extension
 
 The full code of this example is `on GitHub`__.
 
-__ https://github.com/thundernest/sample-extensions/tree/master/experiment
+__ https://github.com/thunderbird/sample-extensions/tree/master/experiment
 
 .. note::
 

--- a/index.rst
+++ b/index.rst
@@ -308,6 +308,6 @@ Where To Get Help And More Information
 
 __ https://developer.thunderbird.net/add-ons/
 __ https://developer.thunderbird.net/add-ons/community
-__ https://github.com/thundernest/sample-extensions
+__ https://github.com/thunderbird/sample-extensions
 __ https://github.com/mdn/webextensions-examples
 __ https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions

--- a/mailTabs.rst
+++ b/mailTabs.rst
@@ -8,8 +8,8 @@ The mailTabs API first appeared in Thunderbird 66 and allows to interact with Th
 
 The `Filter`__  and `Layout`__ sample extensions use this API.
 
-__ https://github.com/thundernest/sample-extensions/tree/master/filter
-__ https://github.com/thundernest/sample-extensions/tree/master/layout
+__ https://github.com/thunderbird/sample-extensions/tree/master/filter
+__ https://github.com/thunderbird/sample-extensions/tree/master/layout
 
 .. role:: permission
 

--- a/mailingLists.rst
+++ b/mailingLists.rst
@@ -8,7 +8,7 @@ The :doc:`addressBooks` API, also including the :doc:`contacts` and :doc:`mailin
 
 The `Address Books`__ sample extension uses this API.
 
-__ https://github.com/thundernest/sample-extensions/tree/master/addressBooks
+__ https://github.com/thunderbird/sample-extensions/tree/master/addressBooks
 
 .. role:: permission
 

--- a/overlay/addressBooks.rst
+++ b/overlay/addressBooks.rst
@@ -6,4 +6,4 @@ The :doc:`addressBooks` API, also including the :doc:`contacts` and :doc:`mailin
 
 The `Address Books`__ sample extension uses this API.
 
-__ https://github.com/thundernest/sample-extensions/tree/master/addressBooks
+__ https://github.com/thunderbird/sample-extensions/tree/master/addressBooks

--- a/overlay/browserAction.rst
+++ b/overlay/browserAction.rst
@@ -7,7 +7,7 @@ The browserAction API first appeared in Thunderbird 64. It is very similar to Fi
 Many of our `sample extensions`__ use a browserAction.
 
 __ https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction
-__ https://github.com/thundernest/sample-extensions
+__ https://github.com/thunderbird/sample-extensions
 
 .. important::
 

--- a/overlay/cloudFile.rst
+++ b/overlay/cloudFile.rst
@@ -6,4 +6,4 @@ The cloudFile (a.k.a. fileLink) API first appeared in Thunderbird 60. It allows 
 
 The `DropBox Uploader`__ sample extension uses this API.
 
-__ https://github.com/thundernest/sample-extensions/tree/master/dropbox
+__ https://github.com/thunderbird/sample-extensions/tree/master/dropbox

--- a/overlay/contacts.rst
+++ b/overlay/contacts.rst
@@ -6,4 +6,4 @@ The :doc:`addressBooks` API, also including the :doc:`contacts` and :doc:`mailin
 
 The `Address Books`__ sample extension uses this API.
 
-__ https://github.com/thundernest/sample-extensions/tree/master/addressBooks
+__ https://github.com/thunderbird/sample-extensions/tree/master/addressBooks

--- a/overlay/mailTabs.rst
+++ b/overlay/mailTabs.rst
@@ -6,5 +6,5 @@ The mailTabs API first appeared in Thunderbird 66 and allows to interact with Th
 
 The `Filter`__  and `Layout`__ sample extensions use this API.
 
-__ https://github.com/thundernest/sample-extensions/tree/master/filter
-__ https://github.com/thundernest/sample-extensions/tree/master/layout
+__ https://github.com/thunderbird/sample-extensions/tree/master/filter
+__ https://github.com/thunderbird/sample-extensions/tree/master/layout

--- a/overlay/mailingLists.rst
+++ b/overlay/mailingLists.rst
@@ -6,4 +6,4 @@ The :doc:`addressBooks` API, also including the :doc:`contacts` and :doc:`mailin
 
 The `Address Books`__ sample extension uses this API.
 
-__ https://github.com/thundernest/sample-extensions/tree/master/addressBooks
+__ https://github.com/thunderbird/sample-extensions/tree/master/addressBooks

--- a/theme.rst
+++ b/theme.rst
@@ -338,7 +338,7 @@ Defines additional color, image and property keys to be used in :ref:`theme.Them
       :name: [``stylesheet``]
       :type: (:ref:`theme.ExtensionURL`, optional)
       
-      URL to a stylesheet introducing additional CSS variables, extending the theme-able areas of Thunderbird. The `theme_experiment add-on in our example repository <https://github.com/thundernest/sample-extensions/tree/master/theme_experiment>`__ is using the stylesheet shown below, to add the :value:`--chat-button-color` CSS color variable: 
+      URL to a stylesheet introducing additional CSS variables, extending the theme-able areas of Thunderbird. The `theme_experiment add-on in our example repository <https://github.com/thunderbird/sample-extensions/tree/master/theme_experiment>`__ is using the stylesheet shown below, to add the :value:`--chat-button-color` CSS color variable:
       
       .. literalinclude:: includes/theme/theme_experiment_style.css
         :language: CSS


### PR DESCRIPTION
@jobisoft lmk if you need a separate PR for latest-mv3. 

This shouldn't be merged until we do the github org rename.